### PR TITLE
Prevent the deploy running on PR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,25 @@
 ---
 kind: "pipeline"
 name: "docs-web"
+steps:
+  - name: "antora"
+    environment:
+      DOCSEARCH_ENABLED: true
+      DOCSEARCH_ENGINE: "lunr"
+      NODE_PATH: "./src/js:/usr/local/lib/node_modules:./node_modules"
+    image: "quay.io/sitewards/antora"
+    commands:
+      - "npm install"
+      - "node node_modules/.bin/antora --generator 'generator' site.yml"
+
+trigger:
+  branch:
+    - "master"
+  event:
+    - "pull_request"
+---
+kind: "pipeline"
+name: "deploy"
 
 steps:
   - name: "antora"
@@ -19,12 +38,6 @@ steps:
       dockerfile: "build/container/Dockerfile"
       json_key:
         from_secret: "GOOGLE_SERVICE_ACCOUNT"
-
----
-kind: "pipeline"
-name: "deployment"
-
-steps:
   - name: "deploy"
     image: "quay.io/littlemanco/helm"
     environment:
@@ -45,6 +58,5 @@ steps:
 trigger:
   branch:
     - "master"
-
-depends_on:
-  - "docs-web"
+  event:
+    - "push"


### PR DESCRIPTION
Currently there is a problem in which the deployment process runs on a
pull request against master.

This is problematic as any user can currently run this pull request,
which in principle allows any user access to the protected variables
only available on master.

This commit attempts to resolve this by limiting the master branch to
the "push" event. It's hoped that this event is triggered on a merge to
the master branch, allowing continuous delivery.

Resolves #31

== Design Notes ==

=== Duplicated docs build ===

It still makes sense to build the documentation but to discard it for
pull requests. This allows testing whether the pull request
documentation is even valid before it's pushed.